### PR TITLE
Expose the prefix on the config instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,10 @@ exports.Config = function Config(values, env, options) {
         return options.version;
     };
 
+    Object.defineProperty(this, 'prefix', {
+        value: options.prefix
+    });
+
     function prefix(key) {
         var isUnprefixed = options.unprefixed.indexOf(key) > -1;
         var prefixed = options.prefix ? options.prefix.toUpperCase() + '_'  + key : key;

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -25,6 +25,19 @@ describe('config', function () {
         assert.equal(config.TEST, 'test');
     });
 
+    it('exposes the prefix', function () {
+        var prefix = 'DOGE';
+        var config = createConfig({}, {prefix: prefix});
+        assert.equal(config.prefix, prefix);
+    });
+
+    it('does not allow the prefix to be changed', function () {
+        var config = createConfig();
+        assert.throws(function () {
+            config.prefix = 'CANT OVERRIDE';
+        });
+    });
+
     describe('.get', function () {
         it('returns the value from the defaults object', function () {
             var config = createConfig();


### PR DESCRIPTION
It can be useful for scripts etc.
